### PR TITLE
Adding SpinOnce to driver, and editing whitespace

### DIFF
--- a/src/driver.cpp
+++ b/src/driver.cpp
@@ -171,7 +171,7 @@ int main(int argc, char* argv[])
 			//Start ROS Publisher
 			ros::Publisher pub = node.advertise<ros_falcon::falconPos>("falconPos",10);        
 
-			ros::Rate loop_rate(1000);
+			ros::Rate loop_rate(100);
 
 			while(node.ok())
 				{

--- a/src/driver.cpp
+++ b/src/driver.cpp
@@ -43,59 +43,61 @@ bool init_falcon(int NoFalcon)
   	cout << "Setting up LibUSB" << endl;
     m_falconDevice.setFalconFirmware<FalconFirmwareNovintSDK>(); //Set Firmware
   	if(!m_falconDevice.open(NoFalcon)) //Open falcon @ index 0  (index needed for multiple falcons, assuming only one connected)
-  	{
-  	    cout << "Failed to find falcon" << endl;
-        return false;
-  	}
+		{
+			cout << "Failed to find falcon" << endl;
+			return false;
+		}
     else
-    {
-        cout << "Falcon Found" << endl;
-    }
+		{
+			cout << "Falcon Found" << endl;
+		}
 
     //There's only one kind of firmware right now, so automatically set that.
 	m_falconDevice.setFalconFirmware<FalconFirmwareNovintSDK>();
+
 	//Next load the firmware to the device	
 	bool skip_checksum = false;
+
 	//See if we have firmware
 	bool firmware_loaded = false;
 	firmware_loaded = m_falconDevice.isFirmwareLoaded();
 	
 	if(!firmware_loaded)
-	{
-		cout << "Loading firmware" << endl;
-		uint8_t* firmware_block;
-		long firmware_size;
 		{
-
-			firmware_block = const_cast<uint8_t*>(NOVINT_FALCON_NVENT_FIRMWARE);
-			firmware_size = NOVINT_FALCON_NVENT_FIRMWARE_SIZE;
-
-
-			for(int i = 0; i < 20; ++i)
+			cout << "Loading firmware" << endl;
+			uint8_t* firmware_block;
+			long firmware_size;
 			{
-				if(!m_falconDevice.getFalconFirmware()->loadFirmware(skip_checksum, NOVINT_FALCON_NVENT_FIRMWARE_SIZE, const_cast<uint8_t*>(NOVINT_FALCON_NVENT_FIRMWARE)))
 
-				{
-					cout << "Firmware loading try failed" <<endl;
-				}
-				else
-				{
-	                firmware_loaded = true;
-                    break;
-                }
-            }
-        }
-    }
+				firmware_block = const_cast<uint8_t*>(NOVINT_FALCON_NVENT_FIRMWARE);
+				firmware_size = NOVINT_FALCON_NVENT_FIRMWARE_SIZE;
+
+
+				for(int i = 0; i < 20; ++i)
+					{
+						if(!m_falconDevice.getFalconFirmware()->loadFirmware(skip_checksum, NOVINT_FALCON_NVENT_FIRMWARE_SIZE, const_cast<uint8_t*>(NOVINT_FALCON_NVENT_FIRMWARE)))
+
+							{
+								cout << "Firmware loading try failed" <<endl;
+							}
+						else
+							{
+								firmware_loaded = true;
+								break;
+							}
+					}
+			}
+		}
     else if(!firmware_loaded)
-    {
-        cout << "No firmware loaded to device, and no firmware specified to load (--nvent_firmware, --test_firmware, etc...). Cannot continue" << endl;
-        return false;
-    }
+		{
+			cout << "No firmware loaded to device, and no firmware specified to load (--nvent_firmware, --test_firmware, etc...). Cannot continue" << endl;
+			return false;
+		}
     if(!firmware_loaded || !m_falconDevice.isFirmwareLoaded())
-    {
-        cout << "No firmware loaded to device, cannot continue" << endl;
-        return false;
-    }
+		{
+			cout << "No firmware loaded to device, cannot continue" << endl;
+			return false;
+		}
     cout << "Firmware loaded" << endl;
     
     m_falconDevice.getFalconFirmware()->setHomingMode(true); //Set homing mode (keep track of encoders !needed!)
@@ -111,28 +113,28 @@ bool init_falcon(int NoFalcon)
         usleep(100000);
         int tryLoad = 0;
         while(!stop && tryLoad < 100)
-        {
-            if(!m_falconDevice.runIOLoop()) continue;
-            if(!m_falconDevice.getFalconFirmware()->isHomed())
-            {
-                if(!homing)
-                {
-                    m_falconDevice.getFalconFirmware()->setLEDStatus(libnifalcon::FalconFirmware::RED_LED);
-                    cout << "Falcon not currently homed. Move control all the way out then push straight all the way in." << endl;
+			{
+				if(!m_falconDevice.runIOLoop()) continue;
+				if(!m_falconDevice.getFalconFirmware()->isHomed())
+					{
+						if(!homing)
+							{
+								m_falconDevice.getFalconFirmware()->setLEDStatus(libnifalcon::FalconFirmware::RED_LED);
+								cout << "Falcon not currently homed. Move control all the way out then push straight all the way in." << endl;
                 
-                }
-                homing = true;
-            }
+							}
+						homing = true;
+					}
 
-            if(homing && m_falconDevice.getFalconFirmware()->isHomed())
-            {
-                m_falconDevice.getFalconFirmware()->setLEDStatus(libnifalcon::FalconFirmware::BLUE_LED);
-                cout << "Falcon homed." << endl;
-                homing_reset = true;
-                stop = true;
-            }
-            tryLoad++;
-        }
+				if(homing && m_falconDevice.getFalconFirmware()->isHomed())
+					{
+						m_falconDevice.getFalconFirmware()->setLEDStatus(libnifalcon::FalconFirmware::BLUE_LED);
+						cout << "Falcon homed." << endl;
+						homing_reset = true;
+						stop = true;
+					}
+				tryLoad++;
+			}
         while(!m_falconDevice.runIOLoop());
     }
     return true;    
@@ -156,43 +158,43 @@ int main(int argc, char* argv[])
     
     //TODO Driver currently assumes there is only one falcon attached 
     if(init_falcon(0))
-    { 
-        cout << "Falcon Initialised Starting ROS Node" << endl;
+		{ 
+			cout << "Falcon Initialised Starting ROS Node" << endl;
 
 
-        m_falconDevice.setFalconKinematic<libnifalcon::FalconKinematicStamper>();
-        ros::NodeHandle node;
+			m_falconDevice.setFalconKinematic<libnifalcon::FalconKinematicStamper>();
+			ros::NodeHandle node;
         
-        //Start ROS Subscriber
-        ros::Subscriber sub = node.subscribe("/falconForce", 10, &forceCallback);
+			//Start ROS Subscriber
+			ros::Subscriber sub = node.subscribe("/falconForce", 10, &forceCallback);
         
-        //Start ROS Publisher
-        ros::Publisher pub = node.advertise<ros_falcon::falconPos>("falconPos",10);        
+			//Start ROS Publisher
+			ros::Publisher pub = node.advertise<ros_falcon::falconPos>("falconPos",10);        
 
-        ros::Rate loop_rate(1000);
+			ros::Rate loop_rate(1000);
 
-        while(node.ok())
-            {
-            if(m_falconDevice.runIOLoop())
-                {
-                    //////////////////////////////////////////////
-                    //Request the current encoder positions:
-                    std::array<double, 3> Pos;
-                    Pos = m_falconDevice.getPosition();
+			while(node.ok())
+				{
+					if(m_falconDevice.runIOLoop())
+						{
+							//////////////////////////////////////////////
+							//Request the current encoder positions:
+							std::array<double, 3> Pos;
+							Pos = m_falconDevice.getPosition();
                     
-                    //Publish ROS values
-                    ros_falcon::falconPos position;
-                    position.X = Pos[0];
-                    position.Y = Pos[1];
-                    position.Z = Pos[2];
-                    pub.publish(position);
+							//Publish ROS values
+							ros_falcon::falconPos position;
+							position.X = Pos[0];
+							position.Y = Pos[1];
+							position.Z = Pos[2];
+							pub.publish(position);
                     
-                }
-			ros::spinOnce();
-            loop_rate.sleep();
-        }
-        m_falconDevice.close();
-    }
+						}
+					ros::spinOnce();
+					loop_rate.sleep();
+				}
+			m_falconDevice.close();
+		}
     
     return 0;
 }

--- a/src/driver.cpp
+++ b/src/driver.cpp
@@ -54,12 +54,12 @@ bool init_falcon(int NoFalcon)
 
     //There's only one kind of firmware right now, so automatically set that.
 	m_falconDevice.setFalconFirmware<FalconFirmwareNovintSDK>();
-	//Next load the firmware to the device
-	
+	//Next load the firmware to the device	
 	bool skip_checksum = false;
 	//See if we have firmware
 	bool firmware_loaded = false;
 	firmware_loaded = m_falconDevice.isFirmwareLoaded();
+	
 	if(!firmware_loaded)
 	{
 		cout << "Loading firmware" << endl;
@@ -80,62 +80,62 @@ bool init_falcon(int NoFalcon)
 				}
 				else
 				{
-					firmware_loaded = true;
-					break;
-				}
-			}
-		}
-	}
-	else if(!firmware_loaded)
-	{
-		cout << "No firmware loaded to device, and no firmware specified to load (--nvent_firmware, --test_firmware, etc...). Cannot continue" << endl;
-		return false;
-	}
-	if(!firmware_loaded || !m_falconDevice.isFirmwareLoaded())
-	{
-		cout << "No firmware loaded to device, cannot continue" << endl;
-		return false;
-	}
-	cout << "Firmware loaded" << endl;
+	                firmware_loaded = true;
+                    break;
+                }
+            }
+        }
+    }
+    else if(!firmware_loaded)
+    {
+        cout << "No firmware loaded to device, and no firmware specified to load (--nvent_firmware, --test_firmware, etc...). Cannot continue" << endl;
+        return false;
+    }
+    if(!firmware_loaded || !m_falconDevice.isFirmwareLoaded())
+    {
+        cout << "No firmware loaded to device, cannot continue" << endl;
+        return false;
+    }
+    cout << "Firmware loaded" << endl;
     
     m_falconDevice.getFalconFirmware()->setHomingMode(true); //Set homing mode (keep track of encoders !needed!)
     cout << "Homing Set" << endl;
     std::array<int, 3> forces;
     m_falconDevice.getFalconFirmware()->setForces(forces);
-  	m_falconDevice.runIOLoop(); //read in data  	
+    m_falconDevice.runIOLoop(); //read in data      
 
-  	{
-	    bool stop = false;
-	    bool homing = false;
-	    bool homing_reset = false;
-	    usleep(100000);
+    {
+        bool stop = false;
+        bool homing = false;
+        bool homing_reset = false;
+        usleep(100000);
         int tryLoad = 0;
-	    while(!stop && tryLoad < 100)
-	    {
-		    if(!m_falconDevice.runIOLoop()) continue;
-		    if(!m_falconDevice.getFalconFirmware()->isHomed())
-		    {
-			    if(!homing)
-			    {
-				    m_falconDevice.getFalconFirmware()->setLEDStatus(libnifalcon::FalconFirmware::RED_LED);
-				    cout << "Falcon not currently homed. Move control all the way out then push straight all the way in." << endl;
-       	        
-			    }
-			    homing = true;
-		    }
+        while(!stop && tryLoad < 100)
+        {
+            if(!m_falconDevice.runIOLoop()) continue;
+            if(!m_falconDevice.getFalconFirmware()->isHomed())
+            {
+                if(!homing)
+                {
+                    m_falconDevice.getFalconFirmware()->setLEDStatus(libnifalcon::FalconFirmware::RED_LED);
+                    cout << "Falcon not currently homed. Move control all the way out then push straight all the way in." << endl;
+                
+                }
+                homing = true;
+            }
 
-		    if(homing && m_falconDevice.getFalconFirmware()->isHomed())
-		    {
-			    m_falconDevice.getFalconFirmware()->setLEDStatus(libnifalcon::FalconFirmware::BLUE_LED);
-			    cout << "Falcon homed." << endl;
-			    homing_reset = true;
-			    stop = true;
-		    }
+            if(homing && m_falconDevice.getFalconFirmware()->isHomed())
+            {
+                m_falconDevice.getFalconFirmware()->setLEDStatus(libnifalcon::FalconFirmware::BLUE_LED);
+                cout << "Falcon homed." << endl;
+                homing_reset = true;
+                stop = true;
+            }
             tryLoad++;
-	    }
+        }
         while(!m_falconDevice.runIOLoop());
     }
-    return true;	
+    return true;    
 }
 
 void forceCallback(const ros_falcon::falconForcesConstPtr& msg)
@@ -144,7 +144,7 @@ void forceCallback(const ros_falcon::falconForcesConstPtr& msg)
     forces[0] = msg->X;
     forces[1] = msg->Y;
     forces[2] = msg->Z;
-	m_falconDevice.setForce(forces);
+    m_falconDevice.setForce(forces);
 
     cout << "set Force" << endl;
     //TODO Add safety to only apply forces for limited time
@@ -172,27 +172,28 @@ int main(int argc, char* argv[])
         ros::Rate loop_rate(1000);
 
         while(node.ok())
-	    {
-		    if(m_falconDevice.runIOLoop())
             {
-		        //////////////////////////////////////////////
-		        //Request the current encoder positions:
-		        std::array<double, 3> Pos;
-		        Pos = m_falconDevice.getPosition();
-
-                //Publish ROS values
-		        ros_falcon::falconPos position;
-                position.X = Pos[0];
-                position.Y = Pos[1];
-                position.Z = Pos[2];
-                pub.publish(position);
-                
-            }
+            if(m_falconDevice.runIOLoop())
+                {
+                    //////////////////////////////////////////////
+                    //Request the current encoder positions:
+                    std::array<double, 3> Pos;
+                    Pos = m_falconDevice.getPosition();
+                    
+                    //Publish ROS values
+                    ros_falcon::falconPos position;
+                    position.X = Pos[0];
+                    position.Y = Pos[1];
+                    position.Z = Pos[2];
+                    pub.publish(position);
+                    
+                }
+			ros::spinOnce();
             loop_rate.sleep();
-	    }
+        }
         m_falconDevice.close();
     }
-
-	return 0;
+    
+    return 0;
 }
 

--- a/src/haptics_arm/haptics_arm.ino
+++ b/src/haptics_arm/haptics_arm.ino
@@ -1,0 +1,66 @@
+ 
+ #define DEBUG 1
+ 
+
+
+ #define BUFFER_SIZE 64
+ uint16_t serialBufferPos;
+ char buffer[BUFFER_SIZE]; //this is the buffer where we store incoming text from the computer
+
+ void setup() {
+    Serial.begin(115200);
+    serialBufferPos = 0;
+    counter = 0;
+    
+    //configure the PCA
+    Wire.begin(); // Initiate the Wire library
+
+    /* pca.init(); */
+
+    /* pca.thrustersOff(); */
+
+    alive = millis();
+    delay(1);
+}
+
+
+void loop() {
+
+  //this is all the stuff we do while the jetson is talking to us
+  if (Serial.available() > 0) {
+
+
+    // Read next byte from serial into buffer
+    buffer[serialBufferPos] = Serial.read();
+
+    #ifdef DEBUG
+     Serial.print("buffer is: ");
+     Serial.println(buffer);
+    #endif
+
+    // Check if we've reached exclamation
+    if (buffer[serialBufferPos] == '!') {
+          Serial.println("Got your command");
+          Serial.println(buffer[0]);
+          Serial.println(buffer[1]);
+          Serial.println(buffer[2]);          
+          // Reset buffer position
+          serialBufferPos = 0;
+          buffer[0] = 0;
+
+    } else {
+      #ifdef DEBUG
+
+      Serial.print("Buffer pos ");
+      Serial.println(serialBufferPos);
+      Serial.println(buffer[serialBufferPos]);
+      
+      #endif
+      serialBufferPos++;
+    }
+    
+  }
+
+    // update the timer
+}//end
+

--- a/src/lynx_node.py
+++ b/src/lynx_node.py
@@ -8,7 +8,7 @@ from std_msgs.msg import Int64, Float64, String, Float64MultiArray
 from std_srvs.srv import Empty, EmptyResponse
 from ros_falcon.msg import falconForces, falconPos
 
-device = '/dev/ttyACM4' # TODO
+device = '/dev/ttyACM1' # TODO
 
 pose_cmds = [0,0,0]
 
@@ -55,20 +55,19 @@ def pose_callback(msg):
     pose_cmds[2] = msg.Z
 
 ##------------------------------------------------------------------------------
-# main
 if __name__ == '__main__':
 
     #!!! this also restarts the arduino! (apparently)
 
-    # print "trying to connect to arduino"
-    # Keep trying to open serial
-    # while True:
-    #     try:
-    #         ser = serial.Serial(device,115200, timeout=0,parity=serial.PARITY_NONE,stopbits=serial.STOPBITS_ONE, bytesize=serial.EIGHTBITS)
-    #         break
-    #     except:
-    #         time.sleep(0.25)
-    #         continue
+    print "trying to connect to arduino"
+   # Keep trying to open serial
+    while True:
+        try:
+            ser = serial.Serial(device,115200, timeout=0,parity=serial.PARITY_NONE,stopbits=serial.STOPBITS_ONE, bytesize=serial.EIGHTBITS)
+            break
+        except:
+            time.sleep(0.25)
+            continue
 
 
     print "found it!"
@@ -80,7 +79,7 @@ if __name__ == '__main__':
     
     pose_sub = rospy.Subscriber('falconPos', falconPos, pose_callback)
     
-    rate = rospy.Rate(10) #100Hz
+    rate = rospy.Rate(1000) #100Hz
 
     while not rospy.is_shutdown():
 
@@ -91,8 +90,8 @@ if __name__ == '__main__':
         #print(temp)
 
         # get thruster cmd
-        # x = ser.readline().strip()
-        # print x
+        x = ser.readline().strip()
+        print x
         
         # if x != '':
         #     msg[x[0]] = x[1:]
@@ -104,6 +103,6 @@ if __name__ == '__main__':
 
         
         force_pub.publish(falconForces(1,1,1))
-        print pose_cmds
+        #print pose_cmds
         
         rate.sleep()

--- a/src/lynx_node.py
+++ b/src/lynx_node.py
@@ -2,22 +2,13 @@
 
 #sgillen - this program serves as a node that offers the arduino up to the rest of the ros system.
 
-
-# the packets send to the arduino should be in the following format: p<data>!
-# p tells the arduino which command to execute, the data that follows will depend on which command this is
-# in general the , character is used as a delimiter, and the ! is used to mark the end of the message
-
-# commands so far
-# t,x0,x1,x2,x3,x4,x5,x6,x7!    - this sets all 8 thruster values
-# d!                            - this requests the most recent depth value from the arduino (TODO)
-
 import serial, time, sys, select
 import rospy
 from std_msgs.msg import Int64, Float64, String, Float64MultiArray
 from std_srvs.srv import Empty, EmptyResponse
 from ros_falcon.msg import falconForces, falconPos
 
-device = '/dev/ttyACM4'
+device = '/dev/ttyACM4' # TODO
 
 pose_cmds = [0,0,0]
 
@@ -67,9 +58,6 @@ def pose_callback(msg):
 # main
 if __name__ == '__main__':
 
-    # map for messages
-    msg = {'t': '', 'd': '', 's': ''}
-
     #!!! this also restarts the arduino! (apparently)
 
     # print "trying to connect to arduino"
@@ -83,34 +71,28 @@ if __name__ == '__main__':
     #         continue
 
 
-    print "found it!@"
+    print "found it!"
     time.sleep(3)
 
-    rospy.init_node('lynx_node', anonymous=False)
-    
 
     force_pub = rospy.Publisher('falconForce', falconForces, queue_size = 10)
+    rospy.init_node('lynx_node', anonymous=False)
+    
     pose_sub = rospy.Subscriber('falconPos', falconPos, pose_callback)
-
-
+    
     rate = rospy.Rate(10) #100Hz
-
-    # zero the thrusters
-    # send_pose_cmds([0,0,0])
 
     while not rospy.is_shutdown():
 
-
-
-       # send_pose_cmds(pose_cmds)
+        #send_pose_cmds(pose_cmds)
 
         #ser.write('c!')
         #temp = ser.readline()
         #print(temp)
 
         # get thruster cmd
-#        x = ser.readline().strip()
-#        print x
+        # x = ser.readline().strip()
+        # print x
         
         # if x != '':
         #     msg[x[0]] = x[1:]
@@ -120,6 +102,8 @@ if __name__ == '__main__':
         #     msg[x[0]] = x[1:]
         #status = ser.readline().strip()
 
+        
+        force_pub.publish(falconForces(1,1,1))
         print pose_cmds
         
         rate.sleep()

--- a/src/lynx_node.py
+++ b/src/lynx_node.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python
+
+#sgillen - this program serves as a node that offers the arduino up to the rest of the ros system.
+
+
+# the packets send to the arduino should be in the following format: p<data>!
+# p tells the arduino which command to execute, the data that follows will depend on which command this is
+# in general the , character is used as a delimiter, and the ! is used to mark the end of the message
+
+# commands so far
+# t,x0,x1,x2,x3,x4,x5,x6,x7!    - this sets all 8 thruster values
+# d!                            - this requests the most recent depth value from the arduino (TODO)
+
+import serial, time, sys, select
+import rospy
+from std_msgs.msg import Int64, Float64, String, Float64MultiArray
+from std_srvs.srv import Empty, EmptyResponse
+from ros_falcon.msg import falconForces, falconPos
+
+device = '/dev/ttyACM4'
+
+pose_cmds = [0,0,0]
+
+# When this gets flipped, send shutdown signal
+shutdown_flag = False
+
+#reads a command from stdin
+def read_cmd_stdin():
+    if sys.stdin in select.select([sys.stdin], [], [], 0)[0]:
+      line = sys.stdin.readline()
+      line = line.rstrip()
+      if line:
+        num_bytes = ser.write(line)
+        print  "bytes sent =", num_bytes
+
+
+#sends an array of ints to the thrusters using the agreed upon protocol
+#the actual over the wire value is t,x,y,z!
+def send_pose_cmds(pose_cmd):
+    cmd_str = "t"
+    for cmd in pose_cmds:
+        cmd_str += (",")
+        cmd_str += (str(cmd))
+
+    cmd_str += ("!")
+    ser.write(cmd_str)
+    #print "arduino return", ser.readline()
+    ##TODO parse return value
+
+
+##------------------------------------------------------------------------------
+# callbacks
+def shutdown_thrusters(srv):
+    global shutdown_flag
+    shutdown_flag = True
+    return EmptyResponse()
+
+def pose_callback(msg):
+#    rospy.loginfo(rospy.get_caller_id() + "I heard %s", msg.X)
+#    print "I heard %s" %msg.X
+    global pose_cmds
+    pose_cmds[0] = msg.X
+    pose_cmds[1] = msg.Y
+    pose_cmds[2] = msg.Z
+
+##------------------------------------------------------------------------------
+# main
+if __name__ == '__main__':
+
+    # map for messages
+    msg = {'t': '', 'd': '', 's': ''}
+
+    #!!! this also restarts the arduino! (apparently)
+
+    # print "trying to connect to arduino"
+    # Keep trying to open serial
+    # while True:
+    #     try:
+    #         ser = serial.Serial(device,115200, timeout=0,parity=serial.PARITY_NONE,stopbits=serial.STOPBITS_ONE, bytesize=serial.EIGHTBITS)
+    #         break
+    #     except:
+    #         time.sleep(0.25)
+    #         continue
+
+
+    print "found it!@"
+    time.sleep(3)
+
+    rospy.init_node('lynx_node', anonymous=False)
+    
+
+    force_pub = rospy.Publisher('falconForce', falconForces, queue_size = 10)
+    pose_sub = rospy.Subscriber('falconPos', falconPos, pose_callback)
+
+
+    rate = rospy.Rate(10) #100Hz
+
+    # zero the thrusters
+    # send_pose_cmds([0,0,0])
+
+    while not rospy.is_shutdown():
+
+
+
+       # send_pose_cmds(pose_cmds)
+
+        #ser.write('c!')
+        #temp = ser.readline()
+        #print(temp)
+
+        # get thruster cmd
+#        x = ser.readline().strip()
+#        print x
+        
+        # if x != '':
+        #     msg[x[0]] = x[1:]
+
+        # x = ser.readline().strip()
+        # if x != '':
+        #     msg[x[0]] = x[1:]
+        #status = ser.readline().strip()
+
+        print pose_cmds
+        
+        rate.sleep()

--- a/src/moveit.py
+++ b/src/moveit.py
@@ -1,0 +1,107 @@
+import sys
+import copy
+import rospy
+import moveit_commander
+import moveit_msgs.msg
+import geometry_msgs.msg
+from math import pi
+from std_msgs.msg import String
+from moveit_commander.conversions import pose_to_list
+from ros_falcon.msg import falconForces, falconPos
+
+
+pose_goal = geometry_msgs.msg.Pose()
+
+
+
+# This callback will take a falconPos message, concert it to a geometry pose message, and then set the "group" pose
+def pose_callback(msg):
+    
+
+    
+    global pose_goal
+    pose_goal.orientation.w = 1.0
+    pose_goal.position.x = msg.X*10.0
+    pose_goal.position.y = msg.Y*10.0
+    pose_goal.position.z = msg.Z*10.0
+
+    print "pose goal now contains: ",  pose_goal.position.x, pose_goal.position.y, pose_goal.position.z
+    #    rospy.loginfo(rospy.get_caller_id() + "I heard %s", msg.X)
+
+    
+if __name__ == "__main__":
+
+    
+    moveit_commander.roscpp_initialize(sys.argv)
+
+    force_pub = rospy.Publisher('falconForce', falconForces, queue_size = 10)
+
+    rospy.init_node('lynx_node',  anonymous=True)
+
+
+    robot = moveit_commander.RobotCommander()
+    scene = moveit_commander.PlanningSceneInterface()
+
+    display_trajectory_publisher = rospy.Publisher('/move_group/display_planned_path',
+                                               moveit_msgs.msg.DisplayTrajectory,
+                                               queue_size=20)
+    
+    rate = rospy.Rate(10) #Hz
+    
+    group_name = "panda_arm"
+    group = moveit_commander.MoveGroupCommander(group_name)
+
+
+    # We can get the name of the reference frame for this robot:
+    planning_frame = group.get_planning_frame()
+    print "============ Reference frame: %s" % planning_frame
+    
+    # We can also print the name of the end-effector link for this group:
+    eef_link = group.get_end_effector_link()
+    print "============ End effector: %s" % eef_link
+    
+    # We can get a list of all the groups in the robot:
+    group_names = robot.get_group_names()
+    print "============ Robot Groups:", robot.get_group_names()
+    
+    # Sometimes for debugging it is useful to print the entire state of the
+    # robot:
+    print "============ Printing robot state"
+    print robot.get_current_state()
+    print ""
+    
+    
+    # We can get the joint values from the group and adjust some of the values:
+    joint_goal = group.get_current_joint_values()
+    joint_goal[0] = 0
+    joint_goal[1] = -pi/4
+    joint_goal[2] = 0
+    joint_goal[3] = -pi/2
+    joint_goal[4] = 0
+    joint_goal[5] = pi/3
+    joint_goal[6] = 0
+
+    # The go command can be called with joint values, poses, or without any
+    # parameters if you have already set the pose or joint target for the group
+    group.go(joint_goal, wait=True)
+    
+    # Calling ``stop()`` ensures that there is no residual movement
+    group.stop()
+
+
+
+    pose_sub = rospy.Subscriber('falconPos', falconPos, pose_callback)    
+
+    while not rospy.is_shutdown():
+
+
+        group.set_pose_target(pose_goal)
+        plan = group.go(wait=True)
+
+        # We probably don't actually want to do this all in a callback
+        
+        # Calling `stop()` ensures that there is no residual movement
+        group.stop()
+        # It is always good to clear your targets after planning with poses.
+        # Note: there is no equivalent function for clear_joint_value_targets()
+        group.clear_pose_targets()


### PR DESCRIPTION
I noticed when I tried to use the "driver" node that the main IO loop never calls rose::spinOnce, so callbacks are never triggered and force never sent to the device. I added spinOnce to the loop. 

I also edited the formatting, there was something off about it on my machine such that it would look fine inside emacs but indentations would be off when viewed on github, think this was a tabs vs spaces issue. I let emacs auto indent everything with the "gnu" styling (which looked like what you were using). Maybe you don't like that though, feel free to only merge the first commit that adds the first commit (or no commits hey it's your code) 